### PR TITLE
Add basic interaction functions for the new tables

### DIFF
--- a/app.arc
+++ b/app.arc
@@ -186,6 +186,18 @@ team_members
   teamId *String
   name usersByTeam
 
+teams
+  sub *String
+  name teamsByUser
+
+teams
+  teamName *String
+  name teamsByName 
+
+teams
+  topic *String
+  name teamsByTopic
+
 @aws
 runtime nodejs24.x
 region us-east-1

--- a/app/lib/kafka.server.ts
+++ b/app/lib/kafka.server.ts
@@ -5,17 +5,56 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Kafka, KafkaJSError } from 'gcn-kafka'
+import type { AclEntry } from 'gcn-kafka'
+import {
+  AclOperationTypes,
+  AclPermissionTypes,
+  AclResourceTypes,
+  Kafka,
+  KafkaJSError,
+  ResourcePatternTypes,
+} from 'gcn-kafka'
 import memoizee from 'memoizee'
 import { custom } from 'openid-client'
 
 import { domain, getEnvOrDieInProduction } from './env.server'
+import { getTeam, userIsTeamAdmin } from './teams.server'
+import type { User } from '~/routes/_auth/user.server'
+
+export type KafkaACL = AclEntry & {
+  aclId?: string
+}
+
+export type UserClientType = 'producer' | 'consumer'
+
+const operations = {
+  consume: [AclOperationTypes.READ, AclOperationTypes.DESCRIBE],
+  produce: [
+    AclOperationTypes.CREATE,
+    AclOperationTypes.READ,
+    AclOperationTypes.WRITE,
+    AclOperationTypes.DESCRIBE,
+  ],
+}
+
+const resourceTypes = [
+  ResourcePatternTypes.LITERAL,
+  ResourcePatternTypes.PREFIXED,
+]
 
 const client_id = getEnvOrDieInProduction('KAFKA_CLIENT_ID') ?? ''
 const client_secret = getEnvOrDieInProduction('KAFKA_CLIENT_SECRET')
 const kafka = new Kafka({
   client_id,
   client_secret,
+  domain,
+})
+
+const admin_client_id = getEnvOrDieInProduction('KAFKA_ADMIN_CLIENT_ID') ?? ''
+const admin_client_secret = getEnvOrDieInProduction('KAFKA_ADMIN_CLIENT_SECRET')
+const adminKafka = new Kafka({
+  client_id: admin_client_id,
+  client_secret: admin_client_secret,
   domain,
 })
 
@@ -84,4 +123,80 @@ if (process.env.ARC_SANDBOX) {
     const producer = await getProducer()
     await producer.send({ topic, messages: [{ value }] })
   }
+}
+
+/**
+ * Creates the Consumer/Producer rules for a new team, once the new team has already been created
+ * @param user
+ * @param teamId
+ */
+export async function createTeamAcls(user: User, teamId: string) {
+  if (!(await userIsTeamAdmin(user.sub, teamId)))
+    throw new Response(null, { status: 403 })
+
+  const team = await getTeam(teamId)
+  if (!team) throw new Response(null, { status: 500 })
+
+  const adminClient = adminKafka.admin()
+  await adminClient.connect()
+  const formattedTeamName = team.teamName.toLowerCase().replaceAll(' ', '_')
+  const consumerAcls = buildAcls(team.topic, formattedTeamName, 'consume')
+  if (team.isPublic) {
+    consumerAcls.push(...buildAcls(team.topic, '*', 'consume'))
+  }
+  const producerAcls = buildAcls(team.topic, formattedTeamName, 'produce')
+  await adminClient.createAcls({ acl: [...consumerAcls, ...producerAcls] })
+}
+
+// This function may be obsolete
+export async function getAclsFromBrokers(user: User, filter?: string) {
+  // validateUser(user)
+  const adminClient = adminKafka.admin()
+  await adminClient.connect()
+  const acls = await adminClient.describeAcls({
+    resourceType: AclResourceTypes.ANY,
+    host: '*',
+    permissionType: AclPermissionTypes.ANY,
+    operation: AclOperationTypes.ANY,
+    resourcePatternType: ResourcePatternTypes.ANY,
+  })
+  await adminClient.disconnect()
+  const results: KafkaACL[] = []
+  for (const item of acls.resources) {
+    results.push(
+      ...item.acls.map((acl) => {
+        return {
+          ...acl,
+          resourceName: item.resourceName,
+          resourceType: item.resourceType,
+          resourcePatternType: item.resourcePatternType,
+        }
+      })
+    )
+  }
+
+  return results
+}
+
+function buildAcls(
+  topic: string,
+  formattedTeamName: string,
+  principalType: 'consume' | 'produce'
+) {
+  return resourceTypes.flatMap((type) =>
+    operations[principalType].map((operation) => {
+      return {
+        resourceType: AclResourceTypes.TOPIC,
+        resourceName: `${topic}${type === ResourcePatternTypes.PREFIXED ? '.' : ''}`,
+        resourcePatternType: type,
+        principal:
+          formattedTeamName == '*'
+            ? 'User:*'
+            : `${principalType}:${formattedTeamName}`,
+        host: '*',
+        operation,
+        permissionType: AclPermissionTypes.ALLOW,
+      }
+    })
+  )
 }

--- a/app/lib/teams.server.ts
+++ b/app/lib/teams.server.ts
@@ -8,6 +8,7 @@
 import { tables } from '@architect/functions'
 import crypto from 'crypto'
 
+import type { UserMetadata } from './user.server'
 import type { User } from '~/routes/_auth/user.server'
 
 export type Team = {
@@ -15,6 +16,7 @@ export type Team = {
   teamName: string
   description: string
   topic: string
+  isPublic: boolean
 }
 
 export type TeamMember = {
@@ -26,7 +28,8 @@ export type TeamMember = {
 export async function createTeam(
   name: string,
   description: string,
-  topic: string
+  topic: string,
+  isPublic: boolean
 ) {
   const db = await tables()
 
@@ -35,6 +38,7 @@ export async function createTeam(
     teamName: name,
     description,
     topic,
+    isPublic,
   }
   await db.teams.put(team)
   return team
@@ -81,10 +85,104 @@ export async function getUsersByTeamId(teamId: string) {
       ':teamId': teamId,
     },
   })
-  return Items as TeamMember[]
+
+  const members = await Promise.all(
+    Items.map((user) => {
+      return {
+        permission: user.permission,
+        ...db.users.get({ sub: user.sub }),
+      }
+    })
+  )
+
+  return members as (UserMetadata & { permission: string })[]
+}
+
+export async function teamNameAlreadyExists(
+  teamName: string
+): Promise<Boolean> {
+  const db = await tables()
+  return (
+    (
+      await db.teams.query({
+        IndexName: 'teamsByName',
+        KeyConditionExpression: 'teamName = :teamName',
+        ExpressionAttributeValues: {
+          ':teamName': teamName,
+        },
+      })
+    ).Items.length > 0
+  )
+}
+
+export async function editTeam(
+  teamId: string,
+  teamName: string,
+  description: string,
+  isPublic: boolean
+) {
+  const db = await tables()
+  await db.teams.update({
+    Key: { teamId },
+    UpdateExpression:
+      'set teamName = :teamName, description = :description, isPublic = :isPublic',
+    ExpressionAttributeValues: {
+      ':teamName': teamName,
+      ':description': description,
+      ':isPublic': isPublic,
+    },
+  })
 }
 
 export async function removeUserFromTeam(sub: string, teamId: string) {
   const db = await tables()
   await db.team_members.delete({ sub, teamId })
+}
+
+export async function getTeam(teamId: string): Promise<Team> {
+  const db = await tables()
+  return await db.teams.get({ teamId })
+}
+
+export async function getTeamsByUserId(sub: string) {
+  const db = await tables()
+  const { Items } = await db.team_members.query({
+    KeyConditionExpression: '#sub = :sub',
+    ExpressionAttributeNames: {
+      '#sub': 'sub',
+    },
+    ExpressionAttributeValues: {
+      ':sub': sub,
+    },
+  })
+
+  return await Promise.all(Items.map((x) => db.teams.get({ teamId: x.teamId })))
+}
+
+export async function userIsTeamAdmin(
+  sub: string,
+  teamId: string
+): Promise<boolean> {
+  const db = await tables()
+  const membership = await db.team_members.get({
+    sub,
+    teamId,
+  })
+
+  return membership && membership.permission === 'admin'
+}
+
+export async function topicExists(topic: string): Promise<boolean> {
+  const db = await tables()
+  return (
+    (
+      await db.teams.query({
+        IndexName: 'teamsByTopic',
+        KeyConditionExpression: 'topic = :topic',
+        ExpressionAttributeValues: {
+          ':topic': topic,
+        },
+      })
+    ).Items.length > 0
+  )
 }

--- a/app/lib/user.server.ts
+++ b/app/lib/user.server.ts
@@ -101,6 +101,7 @@ export async function getUsersKafkaPermissions(
       teamName: team.teamName,
       description: team.description,
       topic: team.topic,
+      isPublic: team.isPublic,
     }
   })
 }

--- a/app/root/header/Header.tsx
+++ b/app/root/header/Header.tsx
@@ -17,7 +17,7 @@ import { useEffect, useState } from 'react'
 import { useClickAnyWhere, useWindowSize } from 'usehooks-ts'
 
 import { Meatball } from '~/components/meatball/Meatball'
-import { useEmail, usePermissionAdmin, useUserIdp } from '~/root'
+import { useEmail, useFeature, usePermissionAdmin, useUserIdp } from '~/root'
 
 import styles from './header.module.css'
 
@@ -72,6 +72,7 @@ export function Header() {
   const email = useEmail()
   const idp = useUserIdp()
   const isAdmin = usePermissionAdmin()
+  const teamsActive = useFeature('TEAMS')
   const [expanded, setExpanded] = useState(false)
   const [userMenuIsOpen, setUserMenuIsOpen] = useState(false)
   const isMobile = useWindowSize().width < 1024
@@ -173,6 +174,11 @@ export function Header() {
                       !idp && (
                         <NavLink key="password" to="/user/password">
                           Reset Password
+                        </NavLink>
+                      ),
+                      teamsActive && (
+                        <NavLink key="teams" to="/user/teams">
+                          Teams
                         </NavLink>
                       ),
                       <NavLink key="credentials" to="/user/credentials">

--- a/app/routes/quickstart.alerts.tsx
+++ b/app/routes/quickstart.alerts.tsx
@@ -5,10 +5,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Form, Link, useSearchParams } from '@remix-run/react'
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { Form, Link, useLoaderData, useSearchParams } from '@remix-run/react'
 import { Button, ButtonGroup, FormGroup, Label } from '@trussworks/react-uswds'
 import { useState } from 'react'
 
+import { getUser } from './_auth/user.server'
 import type { NoticeFormat } from '~/components/NoticeFormat'
 import { NoticeFormatInput } from '~/components/NoticeFormat'
 import { NoticeTypeCheckboxes } from '~/components/NoticeTypeCheckboxes/NoticeTypeCheckboxes'
@@ -20,8 +22,21 @@ export const handle: BreadcrumbHandle & SEOHandle = {
   noIndex: true,
 }
 
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await getUser(request)
+  const url = new URL(request.url)
+  const clientId = url.searchParams.get('clientId')
+  console.log('Sub: ', user?.sub)
+  console.log('clientId', clientId)
+  return {
+    topics: ['one'],
+  }
+}
+
 export default function () {
   const [params] = useSearchParams()
+  const { topics } = useLoaderData<typeof loader>()
+  console.log(topics)
   const alerts = params.getAll('alerts') || undefined
   const [alertsValid, setAlertsValid] = useState(false)
   const clientId = params.get('clientId') || undefined

--- a/app/routes/user.credentials/client_credentials.server.ts
+++ b/app/routes/user.credentials/client_credentials.server.ts
@@ -258,7 +258,7 @@ export async function createClientCredential(
     })
 
   const team = (await db.teams.get({ teamId })) as Team
-  const scope = `${membership.permission}:${team.teamName}`
+  const scope = `${membership.permission}:${team.teamName.toLowerCase().replaceAll(' ', '_')}`
   const { client_id, client_secret } =
     await createClientCredentialInternal(scope)
   const created = Date.now()

--- a/app/routes/user.teams._index.tsx
+++ b/app/routes/user.teams._index.tsx
@@ -1,0 +1,135 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { Link, useFetcher, useLoaderData } from '@remix-run/react'
+import type { ModalRef } from '@trussworks/react-uswds'
+import {
+  Button,
+  Grid,
+  Icon,
+  Modal,
+  ModalFooter,
+  ModalHeading,
+  ModalToggleButton,
+} from '@trussworks/react-uswds'
+import { useRef } from 'react'
+
+import { getUser } from './_auth/user.server'
+import HeadingWithAddButton from '~/components/HeadingWithAddButton'
+import SegmentedCards from '~/components/SegmentedCards'
+import { ToolbarButtonGroup } from '~/components/ToolbarButtonGroup'
+import { getTeamsByUserId } from '~/lib/teams.server'
+import type { SEOHandle } from '~/root/seo'
+
+export const handle: SEOHandle = { noIndex: true }
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await getUser(request)
+  if (!user) throw new Response(null, { status: 403 })
+
+  const teams = await getTeamsByUserId(user.sub)
+  return {
+    teams,
+  }
+}
+
+export default function () {
+  const { teams } = useLoaderData<typeof loader>()
+
+  return (
+    <>
+      <HeadingWithAddButton headingLevel={1}>Teams</HeadingWithAddButton>
+      <p>
+        Manage your created GCN Kafka Teams and your membership to Teams created
+        by other users here. Team membership grants you access to Kafka Topics
+        based on your access level.
+      </p>
+      {teams.length > 0 && (
+        <SegmentedCards>
+          {teams.map((team) => (
+            <TeamCard
+              key={team.teamId}
+              teamId={team.teamId}
+              teamName={team.teamName}
+              description={team.description}
+            />
+          ))}
+        </SegmentedCards>
+      )}
+    </>
+  )
+}
+
+function TeamCard({
+  teamName,
+  teamId,
+  description,
+}: {
+  teamName: string
+  teamId: string
+  description?: string
+}) {
+  const ref = useRef<ModalRef>(null)
+  const fetcher = useFetcher()
+  const disabled = fetcher.state !== 'idle'
+
+  return (
+    <>
+      <Grid row style={disabled ? { opacity: '50%' } : undefined}>
+        <div className="tablet:grid-col flex-fill">
+          <div>
+            <strong>{teamName}</strong>
+          </div>
+          <div>{description}</div>
+        </div>
+        <div className="tablet:grid-col flex-auto margin-y-auto">
+          <ToolbarButtonGroup>
+            <ModalToggleButton
+              opener
+              disabled={disabled}
+              modalRef={ref}
+              type="button"
+              className="usa-button--secondary"
+            >
+              <Icon.Delete role="presentation" className="margin-y-neg-2px" />
+              Delete
+            </ModalToggleButton>
+            <Link to={`edit?teamId=${teamId}`} className="usa-button">
+              Edit
+              <Icon.Edit role="presentation" className="margin-y-neg-2px" />
+            </Link>
+          </ToolbarButtonGroup>
+        </div>
+      </Grid>
+      <Modal
+        id="modal-delete"
+        ref={ref}
+        aria-labelledby="modal-delete-heading"
+        aria-describedby="modal-delete-description"
+        renderToPortal={false} // FIXME: https://github.com/trussworks/react-uswds/pull/1890#issuecomment-1023730448
+      >
+        <fetcher.Form method="POST">
+          <input type="hidden" name="intent" value="delete" />
+          <input type="hidden" name="teamId" value={teamId} />
+          <ModalHeading id="modal-delete-heading">Remove User</ModalHeading>
+          <p id="modal-delete-description">
+            Are you sure that you want to delete this team?
+          </p>
+          <ModalFooter>
+            <ModalToggleButton modalRef={ref} closer outline>
+              Cancel
+            </ModalToggleButton>
+            <Button data-close-modal type="submit">
+              Delete
+            </Button>
+          </ModalFooter>
+        </fetcher.Form>
+      </Modal>
+    </>
+  )
+}

--- a/app/routes/user.teams.edit.tsx
+++ b/app/routes/user.teams.edit.tsx
@@ -1,0 +1,472 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
+import {
+  Form,
+  Link,
+  redirect,
+  useActionData,
+  useFetcher,
+  useLoaderData,
+} from '@remix-run/react'
+import type { ModalRef } from '@trussworks/react-uswds'
+import {
+  Button,
+  ButtonGroup,
+  Checkbox,
+  FormGroup,
+  Grid,
+  Icon,
+  Label,
+  Modal,
+  ModalFooter,
+  ModalHeading,
+  ModalToggleButton,
+  TextInput,
+} from '@trussworks/react-uswds'
+import classnames from 'classnames'
+import { validate } from 'email-validator'
+import { useRef, useState } from 'react'
+
+import { getUser } from './_auth/user.server'
+import { Highlight } from '~/components/Highlight'
+import { ReCAPTCHA } from '~/components/ReCAPTCHA'
+import SegmentedCards from '~/components/SegmentedCards'
+import { ToolbarButtonGroup } from '~/components/ToolbarButtonGroup'
+// import { createTeamAcls } from '~/lib/kafka.server'
+import {
+  type Team,
+  addUserToTeam,
+  createTeam,
+  editTeam,
+  getTeam,
+  getUsersByTeamId,
+  removeUserFromTeam, // teamNameAlreadyExists,
+  topicExists,
+  userIsTeamAdmin,
+} from '~/lib/teams.server'
+import type { UserMetadata } from '~/lib/user.server'
+import { getFormDataString } from '~/lib/utils'
+import { useRecaptchaSiteKey } from '~/root'
+
+export async function action({ request }: ActionFunctionArgs) {
+  const user = await getUser(request)
+  if (!user) throw new Response(null, { status: 403 })
+
+  const data = await request.formData()
+
+  const teamId = getFormDataString(data, 'teamId')
+  const teamName = getFormDataString(data, 'teamName')
+  const description = getFormDataString(data, 'description') ?? ''
+  const intent = getFormDataString(data, 'intent')
+  const isPublic = getFormDataString(data, 'isPublic') == 'on'
+
+  if (intent === 'create') {
+    const topicName = getFormDataString(data, 'topic')
+    if (!topicName || !teamName) return new Response(null, { status: 400 })
+    if (await topicExists(topicName)) {
+      return {
+        topicNameError: 'Topic already exists',
+      }
+    }
+    const team = await createTeam(teamName, description, topicName, isPublic)
+    await addUserToTeam(user, team.teamId, 'admin')
+    // await createTeamAcls(user, team.teamId)
+    return redirect(`/user/teams/edit?teamId=${team.teamId}`)
+  }
+
+  if (intent === 'update') {
+    if (!teamId || !teamName) throw new Response(null, { status: 403 })
+    await editTeam(teamId, teamName, description, isPublic)
+  }
+
+  if (intent === 'delete') {
+    const sub = getFormDataString(data, 'sub')
+    if (!sub) throw new Response(null, { status: 403 })
+    if (!teamId) throw new Response(null, { status: 400 })
+    await removeUserFromTeam(sub, teamId)
+    return null
+  }
+
+  if (intent === 'invite') {
+    const emails = getFormDataString(data, 'users')
+    console.log(emails)
+    return null
+  }
+
+  return redirect('/user/teams')
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await getUser(request)
+  if (!user) throw new Response(null, { status: 403 })
+  const { teamId } = Object.fromEntries(new URL(request.url).searchParams)
+  if (teamId && !userIsTeamAdmin(user.sub, teamId))
+    throw new Response(null, { status: 403 })
+
+  let team: Team = {
+    teamId: '',
+    teamName: '',
+    description: '',
+    topic: '',
+    isPublic: false,
+  }
+  let members: (UserMetadata & { permission: string })[] = []
+  if (teamId !== undefined) {
+    team = await getTeam(teamId)
+    members = await getUsersByTeamId(teamId)
+  }
+
+  return {
+    team,
+    members,
+  }
+}
+
+export default function () {
+  const { team, members } = useLoaderData<typeof loader>()
+  const actionResults = useActionData<typeof action>()
+  const [recaptchaValid, setRecaptchaValid] = useState(!useRecaptchaSiteKey())
+  const [nameValid, setNameValid] = useState(Boolean(team.teamName))
+  const [topicName, setTopicName] = useState(team.topic)
+  const [topicValid, setTopicValid] = useState(Boolean(topicName))
+  const [usersToInvite, setUsersToInvite] = useState<string[]>([])
+  const [emailValid, setEmailValid] = useState(true)
+  const ref = useRef<ModalRef>(null)
+  const fetcher = useFetcher()
+
+  // Any characters that are NOT alphanumeric, periods, underscores, or hyphens
+  const invalidChars = /[^a-zA-Z0-9._-]/g
+
+  const handleTopicInputChange = (value: string) => {
+    if (!team.teamId) {
+      const newValue = value.toLowerCase().replaceAll(invalidChars, '_')
+      setTopicName(newValue)
+      setTopicValid(!invalidChars.test(newValue))
+    }
+  }
+
+  return (
+    <>
+      <h1>{team.teamId ? 'Edit' : 'New'} Team</h1>
+      <Form method="POST">
+        {team.teamId && (
+          <input type="hidden" name="teamId" value={team.teamId} />
+        )}
+        <Label htmlFor="name">
+          Name
+          <span title="required" className="usa-label--required">
+            *
+          </span>
+        </Label>
+        <TextInput
+          autoFocus
+          id="teamName"
+          name="teamName"
+          type="text"
+          defaultValue={team.teamName}
+          autoCorrect="off"
+          className={classnames(
+            'maxw-full',
+            !nameValid ? 'usa-input--error' : ''
+          )}
+          onChange={(e) => {
+            setNameValid(Boolean(e.target.value))
+            handleTopicInputChange(e.target.value)
+          }}
+        />
+        <div className="text-base margin-bottom-1" id="nameDescription">
+          <small>
+            Your team name will be parsed to create your topics. Spaces will be
+            replaced with underscores.
+          </small>
+        </div>
+        <Label htmlFor="topic">Topic</Label>
+        {!team.teamId ? (
+          <TextInput
+            disabled={Boolean(team.teamId)}
+            id="topic"
+            name="topic"
+            value={topicName}
+            className={classnames(!topicValid ? 'usa-input--error' : '')}
+            onChange={(event) => handleTopicInputChange(event.target.value)}
+            type="text"
+          />
+        ) : (
+          <Highlight code={`gcn.notices.${topicName}`} language="txt" />
+        )}
+
+        {actionResults?.topicNameError && (
+          <span className="text-red">{actionResults.topicNameError}</span>
+        )}
+
+        <div className="text-base margin-bottom-1" id="nameDescription">
+          <small>
+            By default, your topic is parsed from your team name and prefixed
+            with `gcn.notices.`. Spaces will be replaced with underscores. You
+            may alter this to be a shorthand that is more convenient. Once set,
+            this value can NOT be changed. follow the If this topic conflicts
+            with existing topics, you may edit it.
+          </small>
+        </div>
+        <Checkbox
+          id="isPublic"
+          name="isPublic"
+          label="Make topics publicly available to all users"
+        />
+        <div className="text-base margin-bottom-1" id="nameDescription">
+          <small>
+            If checked, all users will be able to consume your topics.
+          </small>
+        </div>
+        <Label htmlFor="description">Description</Label>
+        <TextInput
+          id="description"
+          name="description"
+          type="text"
+          defaultValue={team.description}
+          autoCorrect="off"
+        />
+        {!team.teamId && (
+          <ReCAPTCHA
+            onChange={(value) => {
+              setRecaptchaValid(Boolean(value))
+            }}
+          />
+        )}
+        <FormGroup>
+          <ButtonGroup>
+            <Link
+              to=".."
+              type="button"
+              className="usa-button usa-button--outline"
+            >
+              Cancel
+            </Link>
+            <Button
+              name="intent"
+              value={team.teamId ? 'update' : 'create'}
+              disabled={!(nameValid && recaptchaValid)}
+              type="submit"
+            >
+              Submit
+            </Button>
+          </ButtonGroup>
+        </FormGroup>
+      </Form>
+      {team.teamId && (
+        <Grid row>
+          <Grid tablet={{ col: 'fill' }}>
+            <h3>Members</h3>
+          </Grid>
+          <Grid tablet={{ col: 'auto' }}>
+            <ModalToggleButton
+              opener
+              disabled={!team.teamId}
+              modalRef={ref}
+              type="button"
+              className="usa-button"
+            >
+              <Icon.Add role="presentation" className="margin-y-neg-2px" />
+              Add
+            </ModalToggleButton>
+          </Grid>
+        </Grid>
+      )}
+      <SegmentedCards>
+        {members.map((user) => (
+          <UserPermissionCard
+            key={user.sub}
+            name={user.username ?? ''}
+            sub={user.sub}
+            affiliation={user.affiliation ?? ''}
+            permission={user.permission}
+          />
+        ))}
+      </SegmentedCards>
+      <Modal
+        ref={ref}
+        id="modal-add"
+        aria-labelledby="modal-add-heading"
+        aria-describedby="modal-add-description"
+        renderToPortal={false} // FIXME: https://github.com/trussworks/react-uswds/pull/1890#issuecomment-1023730448
+      >
+        <ModalHeading id="modal-add-heading">Add Users to Team</ModalHeading>
+        <TextInput
+          type="email"
+          id="new-user"
+          name="new-user"
+          className={classnames('maxw-full', {
+            'usa-input--error': !emailValid,
+            '': emailValid,
+          })}
+          onKeyDown={(event) => {
+            const valid = validate(event.currentTarget.value)
+            setEmailValid(valid)
+            if (
+              event.key === 'Enter' &&
+              !usersToInvite.includes(event.currentTarget.value) &&
+              valid
+            ) {
+              setUsersToInvite([...usersToInvite, event.currentTarget.value])
+              event.currentTarget.value = ''
+            }
+          }}
+        />
+        <fetcher.Form method="POST">
+          <input type="hidden" name="intent" value="invite" />
+          <input type="hidden" name="users" value={usersToInvite} />
+          <p id="modal-add-description">
+            Enter the email addresses of users you want to invite to your team
+          </p>
+          {usersToInvite.map((addr) => (
+            <div key={addr}>
+              <Grid>
+                <Grid row>
+                  <div className="tablet:grid-col flex-fill">{addr}</div>
+                  <div className="tablet:grid-col flex-auto margin-y-auto">
+                    <Button
+                      type="button"
+                      secondary
+                      outline
+                      onClick={() =>
+                        setUsersToInvite(
+                          usersToInvite.filter((x) => x !== addr)
+                        )
+                      }
+                    >
+                      <Icon.Delete />
+                    </Button>
+                  </div>
+                </Grid>
+              </Grid>
+            </div>
+          ))}
+          <ModalFooter>
+            <ModalToggleButton modalRef={ref} closer outline>
+              Cancel
+            </ModalToggleButton>
+            <Button
+              data-close-modal
+              type="submit"
+              disabled={usersToInvite.length == 0}
+            >
+              Send
+            </Button>
+          </ModalFooter>
+        </fetcher.Form>
+      </Modal>
+    </>
+  )
+}
+
+export function UserPermissionCard({
+  name,
+  sub,
+  affiliation,
+  permission,
+}: {
+  name: string
+  sub: string
+  affiliation: string
+  permission: string
+}) {
+  const ref = useRef<ModalRef>(null)
+  const permissionRef = useRef<ModalRef>(null)
+  const fetcher = useFetcher()
+  const disabled = fetcher.state !== 'idle'
+
+  return (
+    <>
+      <Grid row style={disabled ? { opacity: '50%' } : undefined}>
+        <div className="tablet:grid-col flex-fill">
+          <div>
+            <strong>{name}</strong>
+          </div>
+          <div>Affiliation: {affiliation}</div>
+          <div>
+            Team Permission: {permission}{' '}
+            <ModalToggleButton
+              opener
+              disabled={disabled}
+              modalRef={permissionRef}
+              type="button"
+              unstyled
+            >
+              update
+            </ModalToggleButton>
+          </div>
+        </div>
+        <div className="tablet:grid-col flex-auto margin-y-auto">
+          <ToolbarButtonGroup>
+            <ModalToggleButton
+              opener
+              disabled={disabled}
+              modalRef={ref}
+              type="button"
+              className="usa-button--secondary"
+            >
+              <Icon.Delete role="presentation" className="margin-y-neg-2px" />
+              Delete
+            </ModalToggleButton>
+          </ToolbarButtonGroup>
+        </div>
+      </Grid>
+      <Modal
+        id="modal-delete"
+        ref={ref}
+        aria-labelledby="modal-delete-heading"
+        aria-describedby="modal-delete-description"
+        renderToPortal={false} // FIXME: https://github.com/trussworks/react-uswds/pull/1890#issuecomment-1023730448
+      >
+        <fetcher.Form method="POST">
+          <input type="hidden" name="intent" value="delete" />
+          <input type="hidden" name="sub" value={sub} />
+          <ModalHeading id="modal-delete-heading">Remove User</ModalHeading>
+          <p id="modal-delete-description">
+            Are you sure that you want to remove {name} from this team?
+          </p>
+          <ModalFooter>
+            <ModalToggleButton modalRef={ref} closer outline>
+              Cancel
+            </ModalToggleButton>
+            <Button data-close-modal type="submit">
+              Remove
+            </Button>
+          </ModalFooter>
+        </fetcher.Form>
+      </Modal>
+      <Modal
+        id="modal-permissions"
+        ref={permissionRef}
+        aria-labelledby="modal-permissions-heading"
+        aria-describedby="modal-permissions-description"
+        renderToPortal={false} // FIXME: https://github.com/trussworks/react-uswds/pull/1890#issuecomment-1023730448
+      >
+        <fetcher.Form method="POST">
+          <input type="hidden" name="intent" value="permissions" />
+          <input type="hidden" name="sub" value={sub} />
+          <ModalHeading id="modal-permissions-heading">
+            Update User's Permissions
+          </ModalHeading>
+          <p id="modal-permissions-description">
+            Are you sure that you want to remove {name} from this team?
+          </p>
+          <ModalFooter>
+            <ModalToggleButton modalRef={ref} closer outline>
+              Cancel
+            </ModalToggleButton>
+            <Button data-close-modal type="submit">
+              Update
+            </Button>
+          </ModalFooter>
+        </fetcher.Form>
+      </Modal>
+    </>
+  )
+}

--- a/app/routes/user.teams/route.tsx
+++ b/app/routes/user.teams/route.tsx
@@ -1,0 +1,22 @@
+/*!
+ * Copyright © 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { feature } from '~/lib/env.server'
+import type { BreadcrumbHandle } from '~/root/Title'
+import type { SEOHandle } from '~/root/seo'
+
+export { Outlet as default } from '@remix-run/react'
+
+export const handle: BreadcrumbHandle & SEOHandle = {
+  breadcrumb: 'Teams',
+  noIndex: true,
+}
+
+export async function loader() {
+  if (!feature('TEAMS')) throw new Response(null, { status: 404 })
+  return null
+}

--- a/app/routes/user.tsx
+++ b/app/routes/user.tsx
@@ -40,6 +40,9 @@ export default function () {
                     </NavLink>,
                   ]
                 : []),
+              <NavLink key="teams" to="teams">
+                Teams
+              </NavLink>,
               <NavLink key="credentials" to="credentials">
                 Client Credentials
               </NavLink>,


### PR DESCRIPTION
New client cred creation method behind feature flag, team membership typing, create new creds with new scope format

Move new section under feature flag

Update new table as user interacts with the site

Update the user search behind feature flag

Add routes and library functions for teams

add more edit functionality to teams page

Add index by teamName, check for existing by name, add subimssion errors

Add create acl function beginning

Add check for existing topic

Add checkbox for private, topic name changes

Refine the edit page

Update server to use Consume Produce wording, start updating quickstart alert page, minor updates to team edit page